### PR TITLE
Faster bit processing

### DIFF
--- a/cptv/bitstream.py
+++ b/cptv/bitstream.py
@@ -1,0 +1,53 @@
+import struct
+
+
+class BitStream:
+    """
+    BitStream takes a file like object and allows it to be consumed at
+    various bit widths
+    """
+
+    def __init__(self, fobj):
+        self.s = fobj
+
+    def bytes(self, size):
+        out = self.s.read(size)
+        if len(out) != size:
+            raise EOFError("short read. wanted {}, got {}"
+                           .format(size, len(out)))
+        return out
+
+    def uint8(self):
+        return ord(self.bytes(1))
+
+    def uint32(self):
+        return struct.unpack("<L", self.bytes(4))[0]
+
+    def uint64(self):
+        return struct.unpack("<Q", self.bytes(8))[0]
+
+    def iter_int(self, total_size, bitw):
+        """Return an iterator which processes the the next total_size
+        bytes, generating signed integers of bitw width.
+        """
+        source = self.bytes(total_size)
+        i = 0
+        bits = 0
+        nbits = 0
+        while True:
+            while nbits < bitw:
+                bits |= source[i] << (24 - nbits)
+                nbits += 8
+                i += 1
+            out = twos_comp(bits >> (32 - bitw) & 0xffff, bitw)
+            bits = (bits << bitw) & 0xffffffff
+            nbits -= bitw
+            yield out
+
+
+def twos_comp(v, width):
+    """Convert the signed value with the given bit width to its two's
+    complement representation.
+    """
+    mask = 2**(width - 1)
+    return -(v & mask) + (v & ~mask)

--- a/tests/test_bitstream.py
+++ b/tests/test_bitstream.py
@@ -1,0 +1,46 @@
+import io
+import pytest
+from cptv.bitstream import BitStream
+
+
+def test_single_bytes():
+    b = BitStream(io.BytesIO(b'\xff\xee\xdd'))
+    assert b.bytes(1) == b'\xff'
+    assert b.bytes(1) == b'\xee'
+    assert b.bytes(1) == b'\xdd'
+
+
+def test_multi_bytes():
+    b = BitStream(io.BytesIO(b'\xff\xee\xdd'))
+    assert b.bytes(3) == b'\xff\xee\xdd'
+
+
+def test_not_enough_bytes():
+    b = BitStream(io.BytesIO(b'\xff'))
+    with pytest.raises(EOFError, match="short read. wanted 2, got 1"):
+        b.bytes(2)
+
+
+def test_uint8():
+    b = BitStream(io.BytesIO(b'\xff\x01\x00'))
+    assert b.uint8() == 255
+    assert b.uint8() == 1
+    assert b.uint8() == 0
+
+
+def test_uint32():
+    b = BitStream(io.BytesIO(b'\xff\xee\xdd\xaa'))
+    assert b.uint32() == 0xaaddeeff
+
+
+def test_uint64():
+    b = BitStream(io.BytesIO(b'\xff\xee\xdd\xcc\xbb\xaa\x00\x11'))
+    assert b.uint64() == 0x1100aabbccddeeff
+
+
+def test_iter_int():
+    i = BitStream(io.BytesIO(b'\xf0\x13')).iter_int(2, 4)
+    assert next(i) == -1
+    assert next(i) == 0x0
+    assert next(i) == 0x1
+    assert next(i) == 0x3


### PR DESCRIPTION
Profiling revealed that the 3rd party bitstring package the reason that CPTV parsing was so slow. A BitStream class has now been implemented which is much faster. The API is friendlier to use as well.

A 12s CPTV file previously took about 12.6s to parse on my machine and is now down to under 2.5s (~80% faster).

BitStream has py.test based unit tests.

Fixes #5.