### PR TITLE
Changed  cdef types to long long so they work on 32 bit systems

### DIFF
--- a/cptv/bitstream.pyx
+++ b/cptv/bitstream.pyx
@@ -55,9 +55,9 @@ cdef class BitStream:
         """
         source = self.bytes(total_size)
         cdef int i = 0
-        cdef long bits = 0
+        cdef long long bits = 0
         cdef int nbits = 0
-        cdef long out = 0
+        cdef long long out = 0
         while True:
             while nbits < bitw:
                 bits |= source[i] << (24 - nbits)

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ Example usage::
 
 setup(
     name="cptv",
-    version="0.2.2",
+    version="0.2.3",
     description="Python library for handling Cacophony Project Thermal Video (CPTV) files",
     long_description=long_description,
     url="https://github.com/TheCacophonyProject/python-cptv",


### PR DESCRIPTION
A couple of the variables need to be `long long` or else you get errors on 32 bit systems like the Raspberry Pi. 