### PR TITLE
 Add initial tool for building Python wheels

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: python
 python:
   - "3.5"
   - "3.6"
+  - "3.7"
 
 install:
   - python setup.py install

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ This software is licensed under the Apache License 2.0.
 * Update the version in setup.py and commit.
 * Ensure a Python 3 virtualenv is active.
 * Build the source distribution: `python setup.py sdist --formats=zip`
+* Build Linux binary wheels: `./build-wheels.sh`
 * Tag the release, for example: `git tag -a v0.2.1 -m "0.2.1 release"`
 * Push the tag to Github, for example: `git push origin v0.2.1`
-* Push the release to PyPI, for example: `twine upload dist/cptv-0.2.1.zip`
+* Push the release to PyPI, for example: `twine upload dist/cptv-0.2.1.zip wheelhouse/cptv-0.2.1*.whl`

--- a/_release/build-wheels.sh
+++ b/_release/build-wheels.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# This script runs inside a pypa/manylinux1 Docker container and build
+# Linux wheels for python-cptv.
+
+set -e -x
+
+# Compile wheels
+for PYBIN in /opt/python/cp{35,36,37}*/bin; do
+    "${PYBIN}/pip" wheel /io/ -w wheelhouse/
+done
+
+# Bundle external shared libraries into the wheels
+for whl in wheelhouse/*.whl; do
+    auditwheel repair "$whl" --plat $PLAT -w /io/wheelhouse/
+done

--- a/build-wheels.sh
+++ b/build-wheels.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+# Create Linux binary wheels for supported Python versions.
+#
+# The wheels are created inside a specialised Docker container and the
+# wheels end up in the `wheelhouse` subdirectory.
+
+sudo rm -rf wheelhouse
+
+docker run --rm -e PLAT=manylinux1_x86_64 -v `pwd`:/io quay.io/pypa/manylinux1_x86_64 /io/_release/build-wheels.sh
+
+sudo rm -rf wheelhouse/numpy*


### PR DESCRIPTION
Wheels are built inside a pypa/manylinux1 docker container. This should eventually be done with TravisCI but one step at a time.

Also, start testing on Python 3.7.