### PR TITLE
use native int for bitwise operations

### DIFF
--- a/cptv/writer.py
+++ b/cptv/writer.py
@@ -251,16 +251,17 @@ class Compressor:
         bits = 0  # scratch buffer
         num_bits = 0  # number of bits in use in scratch
         mask = (1 << packed_bit_width) - 1
+        int32Mask = (1 << 32) - 1
+
         for val in vals:
             # working with native python is much faster on bitwise
             bits |= (val.item() & mask) << (32 - packed_bit_width - num_bits)
-
             num_bits += packed_bit_width
             while num_bits >= 8:
-                bits = np.int64(bits)
+                bits = bits
                 result[index] = bits
                 index = index + 1
-                bits <<= 8
+                bits = (bits << 8) & int32Mask
                 num_bits -= 8
 
         if num_bits > 0:

--- a/cptv/writer.py
+++ b/cptv/writer.py
@@ -252,9 +252,9 @@ class Compressor:
         num_bits = 0  # number of bits in use in scratch
         mask = (1 << packed_bit_width) - 1
         pack_into = struct.pack_into
-        for val in vals:
-            # working with native python is much faster on bitwise
-            bits |= (val.item() & mask) << (32 - packed_bit_width - num_bits)
+        # working with native python is much faster on bitwise
+        for val in vals.tolist():
+            bits |= (val & mask) << (32 - packed_bit_width - num_bits)
             num_bits += packed_bit_width
             rem = num_bits % 8
             pack_into(">I", b, index, bits)

--- a/cptv/writer.py
+++ b/cptv/writer.py
@@ -257,7 +257,7 @@ class Compressor:
 
             num_bits += packed_bit_width
             while num_bits >= 8:
-                bits = bits & mask
+                bits = np.int64(bits)
                 result[index] = bits
                 index = index + 1
                 bits <<= 8

--- a/cptv/writer.py
+++ b/cptv/writer.py
@@ -257,11 +257,14 @@ class Compressor:
             bits |= (val & mask) << (32 - packed_bit_width - num_bits)
             num_bits += packed_bit_width
             rem = num_bits % 8
+            bits = bits & ((1 << 32) - 1)
             pack_into(">I", b, index, bits)
-            index += num_bits // 8
+            eights = num_bits // 8
+            index += eights
+            bits = bits << eights * 8
             num_bits = rem
-            bits = bits & ((1 << num_bits) - 1)
         if num_bits > 0:
-            pack_into(">B", b, index, bits)
+            bits = bits >> 24 & ((1 << 8) - 1)
+            pack_into("B", b, index, bits)
 
-        return np.frombuffer(b, "B")
+        return np.frombuffer(b, "b")

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ Cacophony Project Thermal Video (CPTV) files. It works with Python
 
 setup(
     name="cptv",
-    version="1.5.0",
+    version="1.5.2",
     description="Python library for handling Cacophony Project Thermal Video (CPTV) files",
     long_description=long_description,
     url="https://github.com/TheCacophonyProject/python-cptv",


### PR DESCRIPTION
On rasberry pi this makes writing a frame take aboout .12 seconds, while previously it was taking 0.75 seconds.

Still too slow as we get 9 FPS